### PR TITLE
fix "Failed to reset the dma"

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3328-beikeyun-1296mhz.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3328-beikeyun-1296mhz.dts
@@ -179,18 +179,30 @@
 	assigned-clocks = <&cru SCLK_MAC2IO>, <&cru SCLK_MAC2IO_EXT>;
 	assigned-clock-parents = <&gmac_clkin>, <&gmac_clkin>;
 	clock_in_out = "input";
+	phy-handle = <&rtl8211f>;
 	phy-supply = <&vccio_3v3_reg>;
 	phy-mode = "rgmii";
 	pinctrl-names = "default";
 	pinctrl-0 = <&rgmiim1_pins>;
 	snps,aal;
-	snps,pbl = <0x8>;
-        snps,reset-gpio = <&gpio2 RK_PC1 GPIO_ACTIVE_LOW>;
-        snps,reset-active-low;
-        snps,reset-delays-us = <0 20000 100000>;
-	tx_delay = <0x24>;
-	rx_delay = <0x14>;
+	snps,pbl = <0x4>;
+	tx_delay = <0x26>;
+	rx_delay = <0x11>;
 	status = "okay";
+	
+	mdio {
+		compatible = "snps,dwmac-mdio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		rtl8211f: ethernet-phy@0 {
+			reg = <0>;
+			reset-delay-us = <30000>;
+			reset-assert-us = <30000>;
+			reset-deassert-us = <50000>;
+			reset-gpios = <&gpio2 RK_PC1 GPIO_ACTIVE_LOW>;
+		};
+	};
 };
 
 &gpu {


### PR DESCRIPTION
[Fri Jul  9 06:12:41 2021] rk_gmac-dwmac ff540000.ethernet eth0: PHY [stmmac-0:00] driver [RTL8211F Gigabit Ethernet] (irq=POLL)
[Fri Jul  9 06:12:41 2021] rk_gmac-dwmac ff540000.ethernet: Failed to reset the dma
[Fri Jul  9 06:12:41 2021] rk_gmac-dwmac ff540000.ethernet eth0: stmmac_hw_setup: DMA engine initialization failed
[Fri Jul  9 06:12:41 2021] rk_gmac-dwmac ff540000.ethernet eth0: stmmac_open: Hw setup failed

copy from rk3328-a1.dts and ref: https://www.jianshu.com/p/aba4c856ac48